### PR TITLE
ci: use bot token for release please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,5 +10,6 @@ jobs:
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
         with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
           release-type: node
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"ci","section":"CI / CD","hidden":false},{"type":"test","section":"Testing","hidden":false},{"type":"refactor","section":"Refactorings","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'


### PR DESCRIPTION
this fixes the tag on push event trigger

more info: https://github.com/google-github-actions/release-please-action#github-credentials